### PR TITLE
add class review in domain

### DIFF
--- a/backend/uber/Uber/src/main/java/com/st3/uber/domain/Review.java
+++ b/backend/uber/Uber/src/main/java/com/st3/uber/domain/Review.java
@@ -1,0 +1,31 @@
+package com.st3.uber.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "reviews")
+public class Review {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // Link back to Ride
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "ride_id", nullable = false)
+    private Ride ride;
+
+    private Integer driverRating;
+    private Integer vehicleRating;
+
+    @Column(length = 1000)
+    private String reviewComment;
+
+    private LocalDateTime reviewedAt;
+}

--- a/backend/uber/Uber/src/main/java/com/st3/uber/domain/Ride.java
+++ b/backend/uber/Uber/src/main/java/com/st3/uber/domain/Ride.java
@@ -124,13 +124,8 @@ public class Ride {
     @OneToMany(mappedBy = "ride", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PanicEvent> panicEvents = new ArrayList<>();
 
-    private Integer driverRating;
-    private Integer vehicleRating;
-
-    @Column(length = 1000)
-    private String reviewComment;
-
-    private LocalDateTime reviewedAt;
+    @OneToMany(mappedBy = "ride", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Review> reviews = new ArrayList<>();
 
     @OneToMany(mappedBy = "ride", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<InconsistencyReport> inconsistencyReports = new ArrayList<>();


### PR DESCRIPTION
#74 
This pull request refactors how ride reviews are handled in the domain model by introducing a dedicated `Review` entity and updating the `Ride` class to reference this new entity. This change improves the structure and scalability of the review system.

**Review system refactor:**

* Added a new `Review` entity in `Review.java` to represent ride reviews, including fields for driver and vehicle ratings, review comments, and the review timestamp.
* Removed review-related fields (`driverRating`, `vehicleRating`, `reviewComment`, `reviewedAt`) from the `Ride` class and replaced them with a one-to-many relationship to the new `Review` entity, allowing each ride to have multiple reviews.