### PR TITLE
add domain requestChange for drivers

### DIFF
--- a/backend/resources/PreparingDatabase.txt
+++ b/backend/resources/PreparingDatabase.txt
@@ -17,6 +17,7 @@ DROP TABLE IF EXISTS
     passenger_favorite_rides,
     passengers,
     reviews,
+    request_changes,
     ride_passengers,
     ride_pricing,
     ride_stops,
@@ -54,6 +55,7 @@ DELETE FROM reviews;
 DELETE FROM notifications;
 DELETE FROM rides;
 DELETE FROM ride_pricing;
+DELETE FROM request_changes;
 DELETE FROM drivers;
 DELETE FROM passengers;
 DELETE FROM admins;
@@ -73,6 +75,8 @@ ALTER TABLE panic_events AUTO_INCREMENT = 1;
 ALTER TABLE inconsistency_reports AUTO_INCREMENT = 1;
 ALTER TABLE notifications AUTO_INCREMENT = 1;
 ALTER TABLE ride_pricing AUTO_INCREMENT = 1;
+ALTER TABLE request_changes AUTO_INCREMENT = 1;
+
 
 -- ========================================
 -- INSERT VEHICLES (must come before drivers)
@@ -283,6 +287,14 @@ INSERT INTO messages (id, chat_room_id, content, sender_type, sender_id, sent_at
                                                                                       (5, 2, 'I received a complaint about my driving. Can you explain?', 'USER', 6, NOW() - INTERVAL 5 DAY),
                                                                                       (6, 2, 'A passenger reported route inconsistencies. Please ensure you follow GPS directions.', 'ADMIN', 1, NOW() - INTERVAL 5 DAY + INTERVAL 1 HOUR);
 
+-- ======================================== -- INSERT REQUEST CHANGES -- ========================================
+INSERT INTO request_changes (id, driver_id, vehicle_id, name, surname, phone_number, address, profile_image, model, registration_number, seating_capacity, status, requested_at, decided_at) VALUES
+                                                                                                                                                                                                (1, 6, 1, 'Marko', NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'PENDING', NOW() - INTERVAL 30 MINUTE, NULL),
+                                                                                                                                                                                                (2, 7, 2, 'I', NULL, '+381645678902', NULL, NULL, NULL, 'ZR-456-CD', NULL, 'PENDING', NOW() - INTERVAL 2 HOUR, NULL);
+
+
+
+
 -- ========================================
 -- VERIFICATION QUERY
 -- ========================================
@@ -308,4 +320,6 @@ SELECT 'Messages', COUNT(*) FROM messages
 UNION ALL
 SELECT 'Panic Events', COUNT(*) FROM panic_events
 UNION ALL
-SELECT 'Inconsistency Reports', COUNT(*) FROM inconsistency_reports;
+SELECT 'Inconsistency Reports', COUNT(*) FROM inconsistency_reports
+UNION ALL
+SELECT 'Requested changes', COUNT(*) FROM request_changes;

--- a/backend/uber/Uber/src/main/java/com/st3/uber/domain/RequestChange.java
+++ b/backend/uber/Uber/src/main/java/com/st3/uber/domain/RequestChange.java
@@ -1,0 +1,48 @@
+package com.st3.uber.domain;
+
+import com.st3.uber.enums.RequestChangeStatus;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "request_changes")
+@Getter
+@Setter
+public class RequestChange {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+    @ManyToOne
+    @JoinColumn(name = "driver_id", nullable = false)
+    private Driver driver;
+
+    private String name;
+    private String surname;
+    private String phoneNumber;
+    private String address;
+    private String profileImage;
+
+
+    @ManyToOne
+    @JoinColumn(name = "vehicle_id", nullable = false)
+    private Vehicle vehicle;
+
+    private String model;
+    private String registrationNumber;
+    private Integer seatingCapacity;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RequestChangeStatus status = RequestChangeStatus.PENDING;
+
+    @Column(nullable = false)
+    private LocalDateTime requestedAt = LocalDateTime.now();
+
+    private LocalDateTime decidedAt;
+}

--- a/backend/uber/Uber/src/main/java/com/st3/uber/enums/RequestChangeStatus.java
+++ b/backend/uber/Uber/src/main/java/com/st3/uber/enums/RequestChangeStatus.java
@@ -1,0 +1,3 @@
+package com.st3.uber.enums;
+
+public enum RequestChangeStatus { PENDING, APPROVED, DENIED }


### PR DESCRIPTION
#88 
This pull request introduces a new feature for tracking driver and vehicle change requests in the system. It adds a new `request_changes` table to the database, updates the database preparation scripts to handle this table, and implements the corresponding domain model and status enumeration in Java.

Database changes:

* Added `request_changes` to the list of tables dropped, cleaned, and reset in `PreparingDatabase.txt`, ensuring it is included in the database reset and preparation process. [[1]](diffhunk://#diff-5d0d1573188ba3a417db25f54d5a70aff65fed071f8b1ae548ad8e308123d1d7R20) [[2]](diffhunk://#diff-5d0d1573188ba3a417db25f54d5a70aff65fed071f8b1ae548ad8e308123d1d7R58) [[3]](diffhunk://#diff-5d0d1573188ba3a417db25f54d5a70aff65fed071f8b1ae548ad8e308123d1d7R78-R79)
* Inserted sample data into the `request_changes` table and updated the verification query to count its entries. [[1]](diffhunk://#diff-5d0d1573188ba3a417db25f54d5a70aff65fed071f8b1ae548ad8e308123d1d7R290-R297) [[2]](diffhunk://#diff-5d0d1573188ba3a417db25f54d5a70aff65fed071f8b1ae548ad8e308123d1d7L311-R325)

Backend/domain model:

* Added a new `RequestChange` entity class representing driver and vehicle change requests, including fields for driver, vehicle, status, and timestamps.
* Introduced a `RequestChangeStatus` enum to represent the possible statuses (`PENDING`, `APPROVED`, `DENIED`) for a change request.