### PR TITLE
add feat vehicle locations

### DIFF
--- a/mobile/app/src/main/java/com/example/uber3/HomeFragment.java
+++ b/mobile/app/src/main/java/com/example/uber3/HomeFragment.java
@@ -1,6 +1,8 @@
 package com.example.uber3;
 
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -14,6 +16,10 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton;
 public class HomeFragment extends Fragment {
 
     private static final String ARG_ROLE = "role";
+    private static final long VEHICLE_POLL_INTERVAL_MS = 20_000L; // 20 seconds
+
+    private final Handler pollHandler = new Handler(Looper.getMainLooper());
+    private Runnable pollRunnable;
 
     public HomeFragment() {}
 
@@ -36,19 +42,70 @@ public class HomeFragment extends Fragment {
         FloatingActionButton fab = view.findViewById(R.id.bookRideFab);
 
         fab.setOnClickListener(v -> {
-
             fab.hide();
 
             RideBookingFragment sheet = RideBookingFragment.newInstance();
-
             sheet.setOnDismissCallback(fab::show);
-
             MapFragment.setOnLocationSelectedListener(sheet::setPickupFromMap);
-
 
             sheet.show(getParentFragmentManager(), "RideBooking");
         });
 
         return view;
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        getChildFragmentManager().executePendingTransactions();
+        startVehiclePolling();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        startVehiclePolling();
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        stopVehiclePolling();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        stopVehiclePolling();
+    }
+
+    private void startVehiclePolling() {
+        stopVehiclePolling();
+
+        pollRunnable = new Runnable() {
+            @Override
+            public void run() {
+                refreshVehiclesOnMap();
+                pollHandler.postDelayed(this, VEHICLE_POLL_INTERVAL_MS);
+            }
+        };
+
+        pollHandler.post(pollRunnable);
+    }
+
+    private void stopVehiclePolling() {
+        if (pollRunnable != null) {
+            pollHandler.removeCallbacks(pollRunnable);
+            pollRunnable = null;
+        }
+    }
+
+    private void refreshVehiclesOnMap() {
+        MapFragment mapFragment = (MapFragment) getChildFragmentManager()
+                .findFragmentById(R.id.homeMapContainer);
+
+        if (mapFragment != null) {
+            mapFragment.loadAndShowActiveVehicles();
+        }
     }
 }

--- a/mobile/app/src/main/java/com/example/uber3/MapFragment.java
+++ b/mobile/app/src/main/java/com/example/uber3/MapFragment.java
@@ -18,6 +18,10 @@ import org.osmdroid.views.MapView;
 import org.osmdroid.events.MapEventsReceiver;
 import org.osmdroid.views.overlay.MapEventsOverlay;
 
+import com.example.uber3.network.model.location.ActiveVehicle;
+import com.example.uber3.network.service.VehicleService;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -42,6 +46,8 @@ public class MapFragment extends Fragment {
 
     private MapView mapView;
     private final List<Marker> markers = new ArrayList<>();
+
+    private final List<Marker> vehicleMarkers = new ArrayList<>();
 
     private Polyline routeLine;
 
@@ -396,6 +402,63 @@ public class MapFragment extends Fragment {
 
 
 
+    public void loadAndShowActiveVehicles() {
+        VehicleService.getActiveVehicles(requireContext(), new VehicleService.VehiclesCallback() {
+
+            @Override
+            public void onSuccess(List<ActiveVehicle> vehicles) {
+                requireActivity().runOnUiThread(() -> {
+                    clearVehicleMarkers();
+                    for (ActiveVehicle vehicle : vehicles) {
+                        addVehicleMarker(vehicle);
+                    }
+                    mapView.invalidate();
+                });
+            }
+
+            @Override
+            public void onError(String message) {
+                android.util.Log.e("MapFragment", "Vehicle load error: " + message);
+            }
+        });
+    }
+
+    private void addVehicleMarker(ActiveVehicle vehicle) {
+        GeoPoint point = new GeoPoint(vehicle.latitude, vehicle.longitude);
+
+        Marker marker = new Marker(mapView);
+        marker.setPosition(point);
+        marker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
+
+        // Green = available, Red = unavailable
+        int drawableRes = vehicle.available
+                ? R.drawable.ic_car_green
+                : R.drawable.ic_car_red;
+
+        Drawable icon = ContextCompat.getDrawable(requireContext(), drawableRes);
+        marker.setIcon(icon);
+
+        // Popup info
+        String status = vehicle.available ? "Available ✓" : "Unavailable";
+        marker.setTitle(vehicle.registrationNumber);
+        marker.setSnippet(status);
+        marker.setInfoWindow(new org.osmdroid.views.overlay.infowindow.BasicInfoWindow(
+                org.osmdroid.library.R.layout.bonuspack_bubble, mapView));
+
+        vehicleMarkers.add(marker);
+        mapView.getOverlays().add(marker);
+    }
+
+    private void clearVehicleMarkers() {
+        for (Marker m : vehicleMarkers) {
+            mapView.getOverlays().remove(m);
+        }
+        vehicleMarkers.clear();
+    }
+
+    public void refreshVehicles() {
+        loadAndShowActiveVehicles();
+    }
 
 
 

--- a/mobile/app/src/main/java/com/example/uber3/network/api/VehicleApi.java
+++ b/mobile/app/src/main/java/com/example/uber3/network/api/VehicleApi.java
@@ -1,0 +1,14 @@
+package com.example.uber3.network.api;
+
+import com.example.uber3.network.model.location.ActiveVehicle;
+
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.http.GET;
+
+public interface VehicleApi {
+
+    @GET("api/vehicles/active")
+    Call<List<ActiveVehicle>> getActiveVehicles();
+}

--- a/mobile/app/src/main/java/com/example/uber3/network/model/location/ActiveVehicle.java
+++ b/mobile/app/src/main/java/com/example/uber3/network/model/location/ActiveVehicle.java
@@ -1,0 +1,14 @@
+package com.example.uber3.network.model.location;
+
+import com.google.gson.annotations.SerializedName;
+
+public class ActiveVehicle {
+
+    public double latitude;
+
+    public double longitude;
+
+    public boolean available;
+
+    public String registrationNumber;
+}

--- a/mobile/app/src/main/java/com/example/uber3/network/service/VehicleService.java
+++ b/mobile/app/src/main/java/com/example/uber3/network/service/VehicleService.java
@@ -1,0 +1,45 @@
+package com.example.uber3.network.service;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import com.example.uber3.network.api.ApiClient;
+import com.example.uber3.network.api.VehicleApi;
+import com.example.uber3.network.model.location.ActiveVehicle;
+
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class VehicleService {
+
+    public interface VehiclesCallback {
+        void onSuccess(List<ActiveVehicle> vehicles);
+        void onError(String message);
+    }
+
+    public static void getActiveVehicles(Context context, VehiclesCallback callback) {
+        VehicleApi api = ApiClient.getClient(context).create(VehicleApi.class);
+
+        api.getActiveVehicles().enqueue(new Callback<List<ActiveVehicle>>() {
+            @Override
+            public void onResponse(@NonNull Call<List<ActiveVehicle>> call,
+                                   @NonNull Response<List<ActiveVehicle>> response) {
+                if (response.isSuccessful() && response.body() != null) {
+                    callback.onSuccess(response.body());
+                } else {
+                    callback.onError("Failed to load vehicles: " + response.code());
+                }
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<List<ActiveVehicle>> call,
+                                  @NonNull Throwable t) {
+                callback.onError("Network error: " + t.getMessage());
+            }
+        });
+    }
+}

--- a/mobile/app/src/main/res/drawable/ic_car_green.xml
+++ b/mobile/app/src/main/res/drawable/ic_car_green.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <!-- Car body -->
+    <path
+        android:fillColor="#22C55E"
+        android:pathData="M5,11 L6.5,6.5 C6.7,6.2 7.1,6 7.5,6 L16.5,6 C16.9,6 17.3,6.2 17.5,6.5 L19,11 L20,11.5 L20,17 L4,17 L4,11.5 Z" />
+
+    <!-- Windshield -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.7"
+        android:pathData="M7.5,11 L8.5,7.5 L15.5,7.5 L16.5,11 Z" />
+
+    <!-- Left wheel (circle via path) -->
+    <path
+        android:fillColor="#1A1A1A"
+        android:pathData="M7,15 A2,2 0,1,0 7.001,15 Z" />
+    <path
+        android:fillColor="#555555"
+        android:pathData="M7,16 A1,1 0,1,0 7.001,16 Z" />
+
+    <!-- Right wheel (circle via path) -->
+    <path
+        android:fillColor="#1A1A1A"
+        android:pathData="M17,15 A2,2 0,1,0 17.001,15 Z" />
+    <path
+        android:fillColor="#555555"
+        android:pathData="M17,16 A1,1 0,1,0 17.001,16 Z" />
+
+    <!-- Left headlight (rect via path) -->
+    <path
+        android:fillColor="#FDE68A"
+        android:pathData="M4,12 L5.5,12 L5.5,13.5 L4,13.5 Z" />
+
+    <!-- Right headlight (rect via path) -->
+    <path
+        android:fillColor="#FDE68A"
+        android:pathData="M18.5,12 L20,12 L20,13.5 L18.5,13.5 Z" />
+
+</vector>

--- a/mobile/app/src/main/res/drawable/ic_car_red.xml
+++ b/mobile/app/src/main/res/drawable/ic_car_red.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <!-- Car body -->
+    <path
+        android:fillColor="#EF4444"
+        android:pathData="M5,11 L6.5,6.5 C6.7,6.2 7.1,6 7.5,6 L16.5,6 C16.9,6 17.3,6.2 17.5,6.5 L19,11 L20,11.5 L20,17 L4,17 L4,11.5 Z" />
+
+    <!-- Windshield -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.7"
+        android:pathData="M7.5,11 L8.5,7.5 L15.5,7.5 L16.5,11 Z" />
+
+    <!-- Left wheel -->
+    <path
+        android:fillColor="#1A1A1A"
+        android:pathData="M7,15 A2,2 0,1,0 7.001,15 Z" />
+    <path
+        android:fillColor="#555555"
+        android:pathData="M7,16 A1,1 0,1,0 7.001,16 Z" />
+
+    <!-- Right wheel -->
+    <path
+        android:fillColor="#1A1A1A"
+        android:pathData="M17,15 A2,2 0,1,0 17.001,15 Z" />
+    <path
+        android:fillColor="#555555"
+        android:pathData="M17,16 A1,1 0,1,0 17.001,16 Z" />
+
+    <!-- Left headlight -->
+    <path
+        android:fillColor="#FDE68A"
+        android:pathData="M4,12 L5.5,12 L5.5,13.5 L4,13.5 Z" />
+
+    <!-- Right headlight -->
+    <path
+        android:fillColor="#FDE68A"
+        android:pathData="M18.5,12 L20,12 L20,13.5 L18.5,13.5 Z" />
+
+</vector>


### PR DESCRIPTION
#250 
This pull request adds real-time vehicle availability to the map in the app's home screen. Vehicles are fetched from the backend every 20 seconds and displayed as green (available) or red (unavailable) car icons on the map. The implementation includes new network models, API interfaces, service classes, and vector drawable resources for the vehicle markers.

**Vehicle polling and map integration:**

- Implemented periodic polling in `HomeFragment` to refresh active vehicles on the map every 20 seconds, starting and stopping polling appropriately with the fragment's lifecycle. [[1]](diffhunk://#diff-1a84098fe64c3cf380eafbe2f1faadb91b987103241513b4393542d6cf2253cdR19-R22) [[2]](diffhunk://#diff-1a84098fe64c3cf380eafbe2f1faadb91b987103241513b4393542d6cf2253cdL39-R110)
- Added the `loadAndShowActiveVehicles` method in `MapFragment` to fetch vehicles from the backend, clear previous vehicle markers, and display new markers for each vehicle, colored by availability.
- Introduced separate management for vehicle markers in `MapFragment` to avoid interfering with other map overlays.

**Networking and data modeling:**

- Created the `ActiveVehicle` model class to represent vehicle data from the backend.
- Added the `VehicleApi` interface for the `/api/vehicles/active` endpoint and a `VehicleService` class to handle API calls and callbacks for vehicle data. [[1]](diffhunk://#diff-cd8e27d605c6e9d8dde1625dc2bcc810a4e155744b914d7321fa71da96dafed7R1-R14) [[2]](diffhunk://#diff-f869b6992efa3eeef22a89cb19f6479b705d4c2e4b6528889d6182feb4da5d7bR1-R45)

**UI resources:**

- Added new vector drawable resources `ic_car_green.xml` and `ic_car_red.xml` for available and unavailable vehicle markers on the map. [[1]](diffhunk://#diff-0fc4fc784dfe0a0e45264d08678b79c79889262e5c411906c27f8baf6c2054e2R1-R45) [[2]](diffhunk://#diff-e4fb75315f84a73945463544e61642b74e0da326190552e80f93bd94522023e5R1-R45)