### PR TITLE
fix routing display

### DIFF
--- a/mobile/app/src/main/java/com/example/uber3/DriverDashboardFragment.java
+++ b/mobile/app/src/main/java/com/example/uber3/DriverDashboardFragment.java
@@ -186,19 +186,31 @@ public class DriverDashboardFragment extends Fragment {
         btnCancelRide.setOnClickListener(v -> showCancelModal());
         btnPanic.setOnClickListener(v -> confirmAndPanic());
 
-        // Map click → update driver location when IN_PROGRESS
+        // Map tap → update driver location when IN_PROGRESS.
+        // We only treat it as a tap (not a pan/zoom) if the finger barely moved.
+        final float[] touchDownXY = new float[2];
+        final float TAP_SLOP_PX = 20f; // pixels of movement allowed before it's a drag
         mapView.setOnTouchListener((v, event) -> {
-            if (android.view.MotionEvent.ACTION_UP == event.getAction()) {
-                if (selectedRide instanceof DriverRide) {
-                    DriverRide ride = (DriverRide) selectedRide;
-                    if ("IN_PROGRESS".equals(ride.status)) {
-                        GeoPoint tapped = (GeoPoint) mapView.getProjection()
-                                .fromPixels((int) event.getX(), (int) event.getY());
-                        if (tapped != null) {
-                            updateDriverLocationAndCenter(tapped.getLatitude(), tapped.getLongitude());
+            switch (event.getAction()) {
+                case android.view.MotionEvent.ACTION_DOWN:
+                    touchDownXY[0] = event.getX();
+                    touchDownXY[1] = event.getY();
+                    break;
+                case android.view.MotionEvent.ACTION_UP:
+                    float dx = Math.abs(event.getX() - touchDownXY[0]);
+                    float dy = Math.abs(event.getY() - touchDownXY[1]);
+                    boolean isTap = dx < TAP_SLOP_PX && dy < TAP_SLOP_PX;
+                    if (isTap && selectedRide instanceof DriverRide) {
+                        DriverRide ride = (DriverRide) selectedRide;
+                        if ("IN_PROGRESS".equals(ride.status)) {
+                            GeoPoint tapped = (GeoPoint) mapView.getProjection()
+                                    .fromPixels((int) event.getX(), (int) event.getY());
+                            if (tapped != null) {
+                                updateDriverLocationAndCenter(tapped.getLatitude(), tapped.getLongitude());
+                            }
                         }
                     }
-                }
+                    break;
             }
             return false; // let map still handle zoom/pan
         });
@@ -848,17 +860,13 @@ public class DriverDashboardFragment extends Fragment {
     }
 
     private void fitMapToBounds() {
-        // If driver marker exists, center on driver's location with padding for bottom sheet
+        // If driver marker exists, center on driver using the same reliable offset approach
         if (driverMarker != null) {
             GeoPoint driverPos = driverMarker.getPosition();
             mapView.post(() -> {
-                IMapController controller = mapView.getController();
-                controller.setCenter(driverPos);
-                controller.setZoom(15.0); // Closer zoom when centered on driver
-
-                // Add padding to keep driver marker visible above bottom sheet
-                // Bottom sheet is ~360dp max, so add padding to shift center up
-                mapView.setPadding(0, 0, 0, 400);
+                mapView.getController().setZoom(15.0);
+                // Post again after zoom is applied so the projection is accurate
+                mapView.post(() -> centerMapOnDriver(driverPos));
             });
             return;
         }
@@ -878,10 +886,8 @@ public class DriverDashboardFragment extends Fragment {
         }
         if (points.isEmpty()) return;
 
-        // Add bottom padding to account for bottom sheet
-        mapView.setPadding(40, 40, 40, 420);
         BoundingBox box = BoundingBox.fromGeoPoints(points);
-        mapView.post(() -> mapView.zoomToBoundingBox(box, true));
+        mapView.post(() -> mapView.zoomToBoundingBox(box, true, 80));
     }
 
     private void clearMap() {

--- a/mobile/app/src/main/java/com/example/uber3/RideTrackingFragment.java
+++ b/mobile/app/src/main/java/com/example/uber3/RideTrackingFragment.java
@@ -284,7 +284,17 @@ public class RideTrackingFragment extends Fragment {
         layoutLoading.setVisibility(View.GONE);
         layoutError.setVisibility(View.GONE);
         layoutEmpty.setVisibility(View.GONE);
-        mapView.setVisibility(View.VISIBLE);
+        // Hide map (and clear leftover overlays) once the ride is no longer active
+        boolean rideActive = "IN_PROGRESS".equals(currentRide.status)
+                || "ACCEPTED".equals(currentRide.status)
+                || "PENDING".equals(currentRide.status)
+                || "PANIC".equals(currentRide.status);
+        if (rideActive) {
+            mapView.setVisibility(View.VISIBLE);
+        } else {
+            mapView.setVisibility(View.GONE);
+            clearMap();
+        }
 
         // Update status badge
         tvStatus.setText(getStatusText(currentRide.status));
@@ -757,7 +767,13 @@ public class RideTrackingFragment extends Fragment {
 
             @Override
             public void onError(String message) {
-                // Silent failure on background polls
+                // If the server says there's no active ride (204 No Content),
+                // surface the empty state so the passenger sees the ride has ended.
+                if (message != null && message.contains("204")) {
+                    currentRide = null;
+                    showEmpty();
+                }
+                // Other errors: keep showing whatever was last displayed
             }
         };
 
@@ -807,6 +823,12 @@ public class RideTrackingFragment extends Fragment {
         layoutContent.setVisibility(View.GONE);
         layoutError.setVisibility(View.GONE);
         layoutEmpty.setVisibility(View.VISIBLE);
+        // Hide the map and wipe any leftover route/markers so the old
+        // route doesn't show behind the "no rides" message.
+        if (mapView != null) {
+            mapView.setVisibility(View.GONE);
+            clearMap();
+        }
     }
 
     private String getStatusText(String status) {


### PR DESCRIPTION
#267 
This pull request improves user experience and reliability in the ride tracking and driver dashboard screens by refining map interaction handling, map visibility logic, and error state management. The main changes focus on ensuring the map only appears when appropriate, preventing accidental location updates, and providing clearer feedback when a ride ends.

**Map interaction and visibility improvements:**

* Improved tap detection on the map in `DriverDashboardFragment` to distinguish between taps and drags/zooms, preventing accidental driver location updates unless a genuine tap is detected. [[1]](diffhunk://#diff-c2d6cbb495cce8d9dfdc61bdfa4bf8fbfe29ac50ca34f47c11045e00a87aed3dL189-R203) [[2]](diffhunk://#diff-c2d6cbb495cce8d9dfdc61bdfa4bf8fbfe29ac50ca34f47c11045e00a87aed3dR213)
* Updated map centering logic in `fitMapToBounds` to use a more reliable offset approach, ensuring the driver marker remains visible above the bottom sheet, and adjusted bounding box zoom with explicit padding. [[1]](diffhunk://#diff-c2d6cbb495cce8d9dfdc61bdfa4bf8fbfe29ac50ca34f47c11045e00a87aed3dL851-R869) [[2]](diffhunk://#diff-c2d6cbb495cce8d9dfdc61bdfa4bf8fbfe29ac50ca34f47c11045e00a87aed3dL881-R890)
* Enhanced map visibility logic in `RideTrackingFragment` so the map is only shown when a ride is active, and is hidden/cleared when the ride is inactive or ended. [[1]](diffhunk://#diff-b266832c5e2ac6900fa34abfa11372c2350b23c96ead8dcb6bfadd4676da8797R287-R297) [[2]](diffhunk://#diff-b266832c5e2ac6900fa34abfa11372c2350b23c96ead8dcb6bfadd4676da8797R826-R831)

**Error and empty state handling:**

* Improved error handling for ride tracking: when the server responds with "204 No Content" (no active ride), the app now surfaces the empty state to inform the passenger the ride has ended, instead of silently failing.

These changes together make the app more intuitive for drivers and passengers, reduce confusion from lingering map overlays, and ensure that map interactions are intentional.