### PR TITLE
add valid annotations

### DIFF
--- a/backend/uber/Uber/src/main/java/com/st3/uber/controller/PricingController.java
+++ b/backend/uber/Uber/src/main/java/com/st3/uber/controller/PricingController.java
@@ -4,6 +4,7 @@ import com.st3.uber.dto.pricing.PricingChangeRequest;
 import com.st3.uber.dto.pricing.PricingResponse;
 import com.st3.uber.exception.PricingValidationException;
 import com.st3.uber.service.RidePricingService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -35,7 +36,7 @@ public class PricingController {
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE
     )
-    public ResponseEntity<?> updatePricing(@RequestBody PricingChangeRequest request) {
+    public ResponseEntity<?> updatePricing(@RequestBody @Valid PricingChangeRequest request) {
         try {
             PricingResponse updatedPricing = pricingService.updatePricing(request);
             return ResponseEntity.ok(updatedPricing);

--- a/backend/uber/Uber/src/main/java/com/st3/uber/controller/RideController.java
+++ b/backend/uber/Uber/src/main/java/com/st3/uber/controller/RideController.java
@@ -219,7 +219,7 @@ public class RideController {
     @RolesAllowed("PASSENGER")
     public ResponseEntity<SubmitRatingResponse> submitReview(
             @PathVariable Long rideId,
-            @RequestBody SubmitRatingRequest request,
+            @RequestBody @Valid SubmitRatingRequest request,
             @AuthenticationPrincipal Jwt jwt
     ) {
         Long passengerId = jwt.getClaim("uid");

--- a/backend/uber/Uber/src/main/java/com/st3/uber/dto/pricing/PricingChangeRequest.java
+++ b/backend/uber/Uber/src/main/java/com/st3/uber/dto/pricing/PricingChangeRequest.java
@@ -1,9 +1,20 @@
 package com.st3.uber.dto.pricing;
+import jakarta.validation.constraints.*;
 
 public record PricingChangeRequest(
+        @DecimalMin(value = "50.0", message = "Standard base price must be at least 50.0")
+        @DecimalMax(value = "10000.0", message = "Standard base price cannot exceed 10000.0")
         Double standardBasePrice,
+
+        @DecimalMin(value = "50.0", message = "Luxury base price must be at least 50.0")
+        @DecimalMax(value = "10000.0", message = "Luxury base price cannot exceed 10000.0")
         Double luxuryBasePrice,
+
+        @DecimalMin(value = "50.0", message = "Van base price must be at least 50.0")
+        @DecimalMax(value = "10000.0", message = "Van base price cannot exceed 10000.0")
         Double vanBasePrice,
+
+        @DecimalMin(value = "10.0", message = "Price per km must be at least 10.0")
+        @DecimalMax(value = "1000.0", message = "Price per km cannot exceed 1000.0")
         Double pricePerKm
-) {
-}
+) {}

--- a/backend/uber/Uber/src/main/java/com/st3/uber/dto/ride/SubmitRatingRequest.java
+++ b/backend/uber/Uber/src/main/java/com/st3/uber/dto/ride/SubmitRatingRequest.java
@@ -1,9 +1,19 @@
 package com.st3.uber.dto.ride;
 
 
-// POST /api/rides/{id}/rating - Request
+import jakarta.validation.constraints.*;
+
 public record SubmitRatingRequest(
-        Integer driverRating,    // 1-5 or null
-        Integer vehicleRating,   // 1-5 or null
-        String comment           // optional
+        @NotNull(message = "Driver rating is required")
+        @Min(value = 1, message = "Driver rating must be between 1 and 5")
+        @Max(value = 5, message = "Driver rating must be between 1 and 5")
+        Integer driverRating,
+
+        @NotNull(message = "Vehicle rating is required")
+        @Min(value = 1, message = "Vehicle rating must be between 1 and 5")
+        @Max(value = 5, message = "Vehicle rating must be between 1 and 5")
+        Integer vehicleRating,
+
+        @Size(max = 1000, message = "Comment cannot exceed 1000 characters")
+        String comment
 ) {}


### PR DESCRIPTION
#273 
This pull request adds input validation to pricing and ride rating APIs by introducing Jakarta Bean Validation annotations to the relevant DTOs and updating the controllers to enforce validation. This helps ensure that incoming data is within expected ranges and provides meaningful error messages for invalid requests.

**Validation improvements for API request data:**

* Added validation annotations (e.g., `@DecimalMin`, `@DecimalMax`) to the `PricingChangeRequest` record to enforce minimum and maximum values for base prices and price per kilometer.
* Added validation annotations (e.g., `@NotNull`, `@Min`, `@Max`, `@Size`) to the `SubmitRatingRequest` record to require ratings, restrict their range to 1-5, and limit comment length.

**Controller updates to enforce validation:**

* Updated `PricingController` and `RideController` to use the `@Valid` annotation on request bodies, ensuring that validation rules are checked before processing. [[1]](diffhunk://#diff-f045d6b9e4cea67b07cb1d5fca1faf1e3e60fbb29f4d39afe55555ec9a482a43R7) [[2]](diffhunk://#diff-f045d6b9e4cea67b07cb1d5fca1faf1e3e60fbb29f4d39afe55555ec9a482a43L38-R39) [[3]](diffhunk://#diff-27410db33fe25ac7516304d723b04e71cdda85a630ace85770d0011976aafb52L222-R222)